### PR TITLE
fix: ldap error loggin

### DIFF
--- a/src/Authentication/LDAPManager.php
+++ b/src/Authentication/LDAPManager.php
@@ -73,11 +73,15 @@ class LDAPManager
 
         $messages = ['ldapuri' => $ldapuri];
 
-        log_message('info', 'LdapConnect: To LdapUri {ldapuri}', $messages);
+        log_message('info', 'LDAP connect to LdapUri {ldapuri}', $messages);
 
         $this->connection = @ldap_connect($ldapuri);
 
-        log_message('error', json_encode(ldap_error($this->connection)));
+        if ($this->connection) {
+            log_message('info', 'LDAP connect: syntactic check of the provided parameter successful');            
+        } else {
+            log_message('error', 'LDAP connect: syntactic check failed. please check ldap parameter');
+        }
 
         if ($this->isConnected()) {
             $this->auth();
@@ -118,7 +122,13 @@ class LDAPManager
 
         $this->bind = @ldap_bind($this->connection, $ldap_user, $this->password);
 
-        log_message('error', json_encode(ldap_error($this->connection)));
+        if (ldap_error($this->connection) !== "Success") {
+            $errno = strval(ldap_errno($this->connection));
+            $error = json_encode(ldap_error($this->connection));
+            log_message('error', 'LDAP auth Error #{errno}: {error}', ['errno' => $errno, 'error' => $error]);
+        } else {
+            log_message('info', 'LDAP auth successful');
+        }
     }
 
     /**


### PR DESCRIPTION
### `connect()` function
ldap_connect only does a syntactic check. Only if this fails is 'false' returned. ldapconnect returns 'LDAP\Connection' if all parameters are valid, even if the server name, for example, is incorrect and not reachable.

I implemented the output as follows:
INFO - 2024-11-14 06:48:35 --> LDAP connect to LdapUri ldaps://https://server.local:636
ERROR - 2024-11-14 06:48:35 --> LDAP connect: syntactic check failed. please check ldap parameter

or

INFO - 2024-11-14 06:50:38 --> LDAP connect to LdapUri ldaps://server.local:636
INFO - 2024-11-14 06:50:38 --> LDAP connect: syntactic check of the provided parameter successful

### `auth()` function
ERROR - 2024-11-14 06:53:40 --> LDAP auth Error #49:  "Invalid credentials"