### PR TITLE
Feat ldap user format

### DIFF
--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -50,7 +50,6 @@ composer require rakoitde/shieldldap dev-develop
     authldap.use_ldaps              = true
     authldap.username               = 
     authldap.password               = 
-    authldap.ldap_user_format_upn   = false
     ```
 
 2. Check your config
@@ -66,7 +65,7 @@ composer require rakoitde/shieldldap dev-develop
       ldaps_port:             636
       use_ldaps:              true
       ldap_domain:            your-domain
-      ldap_format_username:   DLN - your-domain\username (Down-Level Logon Name)
+      ldap_format_username:   DLN - Down-Level Logon Name (your-domain\username)
       search_base:            dc=your-domain,dc=local
       storePasswordInSession: true
       attributes:             objectSID, distinguishedname, displayName, title, description, cn, givenName, sn, mail, co, telephoneNumber, mobile, company, department, l, postalCode, streetAddress, displayName, samaccountname, thumbnailPhoto, userAccountControl
@@ -142,7 +141,6 @@ composer require rakoitde/shieldldap dev-develop
     authldap.use_ldaps              = true
     authldap.username               = 
     authldap.password               = 
-    authldap.ldap_user_format_upn   = false
     ```
 
 2. Auth.php
@@ -174,7 +172,7 @@ composer require rakoitde/shieldldap dev-develop
     // ...
         public array $views = [
             'login'                       => '\Rakoitde\Shieldldap\Views\login',
-
+        ]
     // ...
 
         public array $passwordValidators = [

--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -50,6 +50,7 @@ composer require rakoitde/shieldldap dev-develop
     authldap.use_ldaps              = true
     authldap.username               = 
     authldap.password               = 
+    authldap.ldap_user_format_upn   = false
     ```
 
 2. Check your config
@@ -65,6 +66,7 @@ composer require rakoitde/shieldldap dev-develop
       ldaps_port:             636
       use_ldaps:              true
       ldap_domain:            your-domain
+      ldap_format_username:   your-domain\username (Down-Level Logon Name)
       search_base:            dc=your-domain,dc=local
       storePasswordInSession: true
       attributes:             objectSID, distinguishedname, displayName, title, description, cn, givenName, sn, mail, co, telephoneNumber, mobile, company, department, l, postalCode, streetAddress, displayName, samaccountname, thumbnailPhoto, userAccountControl
@@ -140,6 +142,7 @@ composer require rakoitde/shieldldap dev-develop
     authldap.use_ldaps              = true
     authldap.username               = 
     authldap.password               = 
+    authldap.ldap_user_format_upn   = false
     ```
 
 2. Auth.php

--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -66,7 +66,7 @@ composer require rakoitde/shieldldap dev-develop
       ldaps_port:             636
       use_ldaps:              true
       ldap_domain:            your-domain
-      ldap_format_username:   your-domain\username (Down-Level Logon Name)
+      ldap_format_username:   DLN - your-domain\username (Down-Level Logon Name)
       search_base:            dc=your-domain,dc=local
       storePasswordInSession: true
       attributes:             objectSID, distinguishedname, displayName, title, description, cn, givenName, sn, mail, co, telephoneNumber, mobile, company, department, l, postalCode, streetAddress, displayName, samaccountname, thumbnailPhoto, userAccountControl

--- a/src/Authentication/LDAPManager.php
+++ b/src/Authentication/LDAPManager.php
@@ -36,6 +36,7 @@ class LDAPManager
     public const UAC_PASSWORD_EXPIRED               = 8388608;   // hex = 0x800000
     public const UAC_TRUSTED_TO_AUTH_FOR_DELEGATION = 16777216;   // hex = 0x1000000
     public const UAC_PARTIAL_SECRETS_ACCOUNT        = 67108864;   // hex = 0x04000000
+    public const LDAP_FORMAT_USERNAME_DEFAULT       = 'DLN';   // Down-Level Logon Name (domain\\username)
 
     protected string $username;
     protected string $password;
@@ -115,7 +116,17 @@ class LDAPManager
     public function auth()
     {
         $ldap_domain = config('AuthLDAP')->ldap_domain;
-        $ldap_user   = $ldap_domain . '\\' . $this->username;
+        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? self::LDAP_FORMAT_USERNAME_DEFAULT;
+
+        switch ($ldap_user_format) {
+            case 'UPN':
+                $ldap_user = $this->username . '@' . $ldap_domain;
+                break;
+            case 'DLN':
+            default:
+                $ldap_user = $ldap_domain . '\\' . $this->username;
+                break;
+        }
 
         ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION, 3);
         ldap_set_option($this->connection, LDAP_OPT_REFERRALS, 0);

--- a/src/Authentication/LDAPManager.php
+++ b/src/Authentication/LDAPManager.php
@@ -36,7 +36,6 @@ class LDAPManager
     public const UAC_PASSWORD_EXPIRED               = 8388608;   // hex = 0x800000
     public const UAC_TRUSTED_TO_AUTH_FOR_DELEGATION = 16777216;   // hex = 0x1000000
     public const UAC_PARTIAL_SECRETS_ACCOUNT        = 67108864;   // hex = 0x04000000
-    public const LDAP_FORMAT_USERNAME_DEFAULT       = 'DLN';   // Down-Level Logon Name (domain\\username)
 
     protected string $username;
     protected string $password;
@@ -115,17 +114,12 @@ class LDAPManager
      */
     public function auth()
     {
-        $ldap_domain = config('AuthLDAP')->ldap_domain;
-        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? self::LDAP_FORMAT_USERNAME_DEFAULT;
+        $ldap_domain          = config('AuthLDAP')->ldap_domain;
+        $ldap_user_format_upn = config('AuthLDAP')->ldap_user_format_upn ?? false;
 
-        switch ($ldap_user_format) {
-            case 'UPN':
-                $ldap_user = $this->username . '@' . $ldap_domain;
-                break;
-            case 'DLN':
-            default:
-                $ldap_user = $ldap_domain . '\\' . $this->username;
-                break;
+        $ldap_user = $ldap_domain . '\\' . $this->username;
+        if ($ldap_user_format_upn) {
+            $ldap_user = $this->username . '@' . $ldap_domain;
         }
 
         ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION, 3);

--- a/src/Authentication/LDAPManager.php
+++ b/src/Authentication/LDAPManager.php
@@ -36,6 +36,7 @@ class LDAPManager
     public const UAC_PASSWORD_EXPIRED               = 8388608;   // hex = 0x800000
     public const UAC_TRUSTED_TO_AUTH_FOR_DELEGATION = 16777216;   // hex = 0x1000000
     public const UAC_PARTIAL_SECRETS_ACCOUNT        = 67108864;   // hex = 0x04000000
+    public const LDAP_FORMAT_USERNAME_DEFAULT       = 'DLN';   // Down-Level Logon Name (domain\\username)
 
     protected string $username;
     protected string $password;
@@ -114,12 +115,17 @@ class LDAPManager
      */
     public function auth()
     {
-        $ldap_domain          = config('AuthLDAP')->ldap_domain;
-        $ldap_user_format_upn = config('AuthLDAP')->ldap_user_format_upn ?? false;
+        $ldap_domain = config('AuthLDAP')->ldap_domain;
+        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? self::LDAP_FORMAT_USERNAME_DEFAULT;
 
-        $ldap_user = $ldap_domain . '\\' . $this->username;
-        if ($ldap_user_format_upn) {
-            $ldap_user = $this->username . '@' . $ldap_domain;
+        switch ($ldap_user_format) {
+            case 'UPN':
+                $ldap_user = $this->username . '@' . $ldap_domain;
+                break;
+            case 'DLN':
+            default:
+                $ldap_user = $ldap_domain . '\\' . $this->username;
+                break;
         }
 
         ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION, 3);

--- a/src/Authentication/LDAPManager.php
+++ b/src/Authentication/LDAPManager.php
@@ -36,11 +36,11 @@ class LDAPManager
     public const UAC_PASSWORD_EXPIRED               = 8388608;   // hex = 0x800000
     public const UAC_TRUSTED_TO_AUTH_FOR_DELEGATION = 16777216;   // hex = 0x1000000
     public const UAC_PARTIAL_SECRETS_ACCOUNT        = 67108864;   // hex = 0x04000000
-    public const LDAP_FORMAT_USERNAME_DEFAULT       = 'DLN';   // Down-Level Logon Name (domain\\username)
+    public const LDAP_FORMAT_USERNAME_DEFAULT       = 'DLN';   // Down-Level Logon Name (domain\username)
 
     protected string $username;
     protected string $password;
-    protected Connection|bool $connection;
+    protected bool|Connection $connection;
     protected bool $bind = false;
     protected string $dn;
     protected string $ldap_error;
@@ -79,7 +79,7 @@ class LDAPManager
         $this->connection = @ldap_connect($ldapuri);
 
         if ($this->connection) {
-            log_message('info', 'LDAP connect: syntactic check of the provided parameter successful');            
+            log_message('info', 'LDAP connect: syntactic check of the provided parameter successful');
         } else {
             log_message('error', 'LDAP connect: syntactic check failed. please check ldap parameter');
         }
@@ -115,10 +115,10 @@ class LDAPManager
      */
     public function auth()
     {
-        $ldap_domain = config('AuthLDAP')->ldap_domain;
+        $ldap_domain      = config('AuthLDAP')->ldap_domain;
         $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? self::LDAP_FORMAT_USERNAME_DEFAULT;
 
-        switch ($ldap_user_format) {
+        switch (strtoupper($ldap_user_format)) {
             case 'UPN':
                 $ldap_user = $this->username . '@' . $ldap_domain;
                 break;

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -229,8 +229,8 @@ class CheckCommand extends BaseCommand
     private function getLdapFormatDescription(string $format): string
     {
         $descriptions = [
-            'UPN' => 'User Principal Name (username@domain)',
-            'DLN' => 'Down-Level Logon Name (domain\\username)',
+            'UPN' => 'User Principal Name (username@your-domain)',
+            'DLN' => 'Down-Level Logon Name (your-domain\\username)',
         ];
 
         return $descriptions[$format] ?? 'Unknown format';

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -7,9 +7,12 @@ namespace Rakoitde\Shieldldap\Commands;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use LDAP\Connection;
+use Rakoitde\Shieldldap\Config\AuthLDAP;
 
 class CheckCommand extends BaseCommand
 {
+    public const LDAP_FORMAT_USERNAME_DEFAULT = 'DLN';   // Down-Level Logon Name (domain\username)
+
     /**
      * The Command's Group
      *
@@ -57,7 +60,7 @@ class CheckCommand extends BaseCommand
 
     protected string $username = '';
     protected string $password = '';
-    protected Connection|bool $connection;
+    protected bool|Connection $connection;
     protected bool $bind = false;
     protected AuthLDAP $config;
 
@@ -89,7 +92,7 @@ class CheckCommand extends BaseCommand
         CLI::write('  ldaps_port:             ' . CLI::color($ldapConfig->ldaps_port, 'white'), 'green');
         CLI::write('  use_ldaps:              ' . CLI::color($ldapConfig->use_ldaps ? 'true' : 'false', 'white'), 'green');
         CLI::write('  ldap_domain:            ' . CLI::color($ldapConfig->ldap_domain, 'white'), 'green');
-        CLI::write('  ldap_format_username:   ' . CLI::color($ldapConfig->ldap_user_format  . ' (' . $this->getLdapFormatDescription($ldapConfig->ldap_user_format) . ')', 'white'), 'green');
+        CLI::write('  ldap_format_username:   ' . CLI::color($ldapConfig->ldap_user_format . ' - ' . $this->getLdapFormatDescription($ldapConfig->ldap_user_format), 'white'), 'green');
         CLI::write('  search_base:            ' . CLI::color($ldapConfig->search_base, 'white'), 'green');
         CLI::write('  storePasswordInSession: ' . CLI::color($ldapConfig->storePasswordInSession ? 'true' : 'false', 'white'), 'green');
         CLI::write('  attributes:             ' . CLI::color(implode(', ', $ldapConfig->attributes), 'white'), 'green');
@@ -187,10 +190,10 @@ class CheckCommand extends BaseCommand
      */
     public function bind()
     {
-        $ldap_domain = config('AuthLDAP')->ldap_domain;
-        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? 'DLN';
+        $ldap_domain      = config('AuthLDAP')->ldap_domain;
+        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? self::LDAP_FORMAT_USERNAME_DEFAULT;
 
-        switch ($ldap_user_format) {
+        switch (strtoupper($ldap_user_format)) {
             case 'UPN':
                 $ldap_user = $this->username . '@' . $ldap_domain;
                 break;
@@ -219,7 +222,7 @@ class CheckCommand extends BaseCommand
 
         return $bind;
     }
-    
+
     /**
      * Get LDAP format username description
      */

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -89,7 +89,7 @@ class CheckCommand extends BaseCommand
         CLI::write('  ldaps_port:             ' . CLI::color($ldapConfig->ldaps_port, 'white'), 'green');
         CLI::write('  use_ldaps:              ' . CLI::color($ldapConfig->use_ldaps ? 'true' : 'false', 'white'), 'green');
         CLI::write('  ldap_domain:            ' . CLI::color($ldapConfig->ldap_domain, 'white'), 'green');
-        CLI::write('  ldap_format_username:   ' . CLI::color('(' . $this->getLdapFormatDescription($ldapConfig->ldap_user_format_upn) . ')', 'white'), 'green');
+        CLI::write('  ldap_format_username:   ' . CLI::color($ldapConfig->ldap_user_format  . ' (' . $this->getLdapFormatDescription($ldapConfig->ldap_user_format) . ')', 'white'), 'green');
         CLI::write('  search_base:            ' . CLI::color($ldapConfig->search_base, 'white'), 'green');
         CLI::write('  storePasswordInSession: ' . CLI::color($ldapConfig->storePasswordInSession ? 'true' : 'false', 'white'), 'green');
         CLI::write('  attributes:             ' . CLI::color(implode(', ', $ldapConfig->attributes), 'white'), 'green');
@@ -188,11 +188,16 @@ class CheckCommand extends BaseCommand
     public function bind()
     {
         $ldap_domain = config('AuthLDAP')->ldap_domain;
-        $ldap_user_format_upn = config('AuthLDAP')->ldap_user_format_upn ?? false;
+        $ldap_user_format = config('AuthLDAP')->ldap_user_format ?? 'DLN';
 
-        $ldap_user = $ldap_domain . '\\' . $this->username;
-        if ($ldap_user_format_upn) {
-            $ldap_user = $this->username . '@' . $ldap_domain;
+        switch ($ldap_user_format) {
+            case 'UPN':
+                $ldap_user = $this->username . '@' . $ldap_domain;
+                break;
+            case 'DLN':
+            default:
+                $ldap_user = $ldap_domain . '\\' . $this->username;
+                break;
         }
 
         CLI::write('  bind user:       ' . CLI::color($this->username, 'white'), 'green');
@@ -218,10 +223,13 @@ class CheckCommand extends BaseCommand
     /**
      * Get LDAP format username description
      */
-    private function getLdapFormatDescription(bool $ldap_user_format = false): string
+    private function getLdapFormatDescription(string $format): string
     {
-        return $ldap_user_format 
-            ? 'username@domain (User Principal Name)'
-            : 'domain\username (Down-Level Logon Name)';
+        $descriptions = [
+            'UPN' => 'User Principal Name (username@domain)',
+            'DLN' => 'Down-Level Logon Name (domain\\username)',
+        ];
+
+        return $descriptions[$format] ?? 'Unknown format';
     }
 }

--- a/src/Config/AuthLDAP.php
+++ b/src/Config/AuthLDAP.php
@@ -17,6 +17,9 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public const RECORD_LOGIN_ATTEMPT_NONE    = 0; // Do not record at all
     public const RECORD_LOGIN_ATTEMPT_FAILURE = 1; // Record only failures
     public const RECORD_LOGIN_ATTEMPT_ALL     = 2; // Record all login attempts
+    
+    public const FORMAT_AUTHENTICATION_DLN    = 'DLN';  // Down-Level Logon Name (domain\username)
+    public const FORMAT_AUTHENTICATION_UPN    = 'UPN';  // User Principal Name (username@domain)
 
     /**
      * The ldap hostname to connect to
@@ -54,11 +57,16 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public string $password = 'password';
 
     /**
-     * The LDAP user format
-     * false = Down-Level Logon Name format (domain\username)
-     * true  = User Principal Name format (username@domain)
+     * --------------------------------------------------------------------
+     * Format authentication username login
+     * --------------------------------------------------------------------
+     * The format of the username to use when authenticating Ldap.
+     *
+     * Valid values are:
+     * - self::FORMAT_AUTHENTICATION_DLN - domain\username (default)
+     * - self::FORMAT_AUTHENTICATION_UPN - username@domain
      */
-    public bool $ldap_user_format_upn = false;
+    public $ldap_user_format = self::FORMAT_AUTHENTICATION_DLN;
 
     /**
      * The ldaps searchbase like "dc=int,dc=company,dc=local"

--- a/src/Config/AuthLDAP.php
+++ b/src/Config/AuthLDAP.php
@@ -17,7 +17,6 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public const RECORD_LOGIN_ATTEMPT_NONE    = 0; // Do not record at all
     public const RECORD_LOGIN_ATTEMPT_FAILURE = 1; // Record only failures
     public const RECORD_LOGIN_ATTEMPT_ALL     = 2; // Record all login attempts
-    
     public const FORMAT_AUTHENTICATION_DLN    = 'DLN';  // Down-Level Logon Name (domain\username)
     public const FORMAT_AUTHENTICATION_UPN    = 'UPN';  // User Principal Name (username@domain)
 
@@ -66,7 +65,7 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
      * - self::FORMAT_AUTHENTICATION_DLN - domain\username (default)
      * - self::FORMAT_AUTHENTICATION_UPN - username@domain
      */
-    public $ldap_user_format = self::FORMAT_AUTHENTICATION_DLN;
+    public string $ldap_user_format = self::FORMAT_AUTHENTICATION_DLN;
 
     /**
      * The ldaps searchbase like "dc=int,dc=company,dc=local"

--- a/src/Config/AuthLDAP.php
+++ b/src/Config/AuthLDAP.php
@@ -17,9 +17,6 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public const RECORD_LOGIN_ATTEMPT_NONE    = 0; // Do not record at all
     public const RECORD_LOGIN_ATTEMPT_FAILURE = 1; // Record only failures
     public const RECORD_LOGIN_ATTEMPT_ALL     = 2; // Record all login attempts
-    
-    public const FORMAT_AUTHENTICATION_DLN    = 'DLN';  // Down-Level Logon Name (domain\username)
-    public const FORMAT_AUTHENTICATION_UPN    = 'UPN';  // User Principal Name (username@domain)
 
     /**
      * The ldap hostname to connect to
@@ -57,16 +54,11 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public string $password = 'password';
 
     /**
-     * --------------------------------------------------------------------
-     * Format authentication username login
-     * --------------------------------------------------------------------
-     * The format of the username to use when authenticating Ldap.
-     *
-     * Valid values are:
-     * - self::FORMAT_AUTHENTICATION_DLN - domain\username (default)
-     * - self::FORMAT_AUTHENTICATION_UPN - username@domain
+     * The LDAP user format
+     * false = Down-Level Logon Name format (domain\username)
+     * true  = User Principal Name format (username@domain)
      */
-    public $ldap_user_format = self::FORMAT_AUTHENTICATION_DLN;
+    public bool $ldap_user_format_upn = false;
 
     /**
      * The ldaps searchbase like "dc=int,dc=company,dc=local"

--- a/src/Config/AuthLDAP.php
+++ b/src/Config/AuthLDAP.php
@@ -17,6 +17,9 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
     public const RECORD_LOGIN_ATTEMPT_NONE    = 0; // Do not record at all
     public const RECORD_LOGIN_ATTEMPT_FAILURE = 1; // Record only failures
     public const RECORD_LOGIN_ATTEMPT_ALL     = 2; // Record all login attempts
+    
+    public const FORMAT_AUTHENTICATION_DLN    = 'DLN';  // Down-Level Logon Name (domain\username)
+    public const FORMAT_AUTHENTICATION_UPN    = 'UPN';  // User Principal Name (username@domain)
 
     /**
      * The ldap hostname to connect to
@@ -52,6 +55,18 @@ class AuthLDAP extends BaseConfig // class AuthLDAP extends ShieldAuthLDAP
      * Password
      */
     public string $password = 'password';
+
+    /**
+     * --------------------------------------------------------------------
+     * Format authentication username login
+     * --------------------------------------------------------------------
+     * The format of the username to use when authenticating Ldap.
+     *
+     * Valid values are:
+     * - self::FORMAT_AUTHENTICATION_DLN - domain\username (default)
+     * - self::FORMAT_AUTHENTICATION_UPN - username@domain
+     */
+    public $ldap_user_format = self::FORMAT_AUTHENTICATION_DLN;
 
     /**
      * The ldaps searchbase like "dc=int,dc=company,dc=local"


### PR DESCRIPTION
## Description of the problem
LDAP authentication fails in some environments due to the way the LDAP username is constructed.

## Proposed solution
I have added a new configuration parameter `ldap_user_format_upn` that allows users to choose between two standard LDAP username formats:
- `false`: Domain\Username (Default, "Down-Level Logon Name")
- `true`: Username@Domain ("User Principal Name")

## Changes made
- Added new boolean configuration parameter `ldap_user_format_upn` in `Config/AuthLDAP.php`
- Modified `LDAPManager::auth()` method in `Authentication/LDAPManager.php` to use the new configuration
- Updated `CheckCommand::showConfig()` method in `Commands/CheckCommand.php` to display the `ldap_user_format_upn` configuration parameter along with a description of the format
- Modified `CheckCommand::bind()` method to use the new configuration
- Updated relevant documentation to reflect these changes

## How to test
1. Set `ldap_user_format_upn` in `Config/AuthLDAP.php` to `false` or `true`
2. Attempt to authenticate with LDAP
3. Verify that the authentication works correctly with both formats:
   - When `false`, it should use the format "Domain\Username"
   - When `true`, it should use the format "Username@Domain"

## Additional notes
This change is backwards compatible. The default behavior (Down-Level Logon Name format) remains unchanged unless explicitly configured to use UPN format.